### PR TITLE
Fixes errors on latest Vagrant and Ansible

### DIFF
--- a/tool/Vagrantfile
+++ b/tool/Vagrantfile
@@ -66,6 +66,6 @@ Vagrant.configure(2) do |config|
   # documentation for more information about their specific syntax and use.
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "playbook.yml"
-    ansible.sudo = true
+    ansible.become = true
   end
 end

--- a/tool/playbook.yml
+++ b/tool/playbook.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: all
   vars:
-    home_dir: /home/ubuntu
+    home_dir: /home/vagrant
     xsupplicant_src: "{{ home_dir }}/xsupplicant"
     xsupplicant_repo: https://gitlab.ais.cmc.osaka-u.ac.jp/tis/xsupplicant.git
     mnexec_url: https://raw.githubusercontent.com/mininet/mininet/96ea5367dbea7b77e6b7454c1de85b30b7ba7035/mnexec.c


### PR DESCRIPTION
Fixes following errors when running `vagrant up`:

```
Destination /home/ubuntu is not writable
```

```
The following settings shouldn't exist: become
```

Tested against:
- Vagrant 2.0.1
- Ansible 2.4.2.0
- Box ubuntu/xenial64 20180112.0.0